### PR TITLE
Add token-based API authentication endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,11 @@ REDIS_HOST=127.0.0.1
 REDIS_PASSWORD=null
 REDIS_PORT=6379
 
+# API authentication and rate limiting
+API_RATE_LIMIT=120
+API_AUTH_RATE_LIMIT=10
+API_TOKEN_EXPIRATION=43200
+
 # Mail handling settings
 MAIL_MAILER=smtp
 MAIL_HOST=smtp.mailtrap.io

--- a/app/Http/Controllers/Api/ApiTokenController.php
+++ b/app/Http/Controllers/Api/ApiTokenController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\ApiToken;
+use App\Models\User;
+use Carbon\CarbonInterface;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class ApiTokenController extends Controller
+{
+    /**
+     * Issue a new API token for an authenticated user.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'login' => ['required', 'string'],
+            'password' => ['required', 'string'],
+            'device_name' => ['nullable', 'string', 'max:255'],
+            'abilities' => ['nullable', 'array'],
+            'abilities.*' => ['string'],
+        ]);
+
+        $user = User::where('login', $validated['login'])->first();
+
+        if (! $user || ! Hash::check($validated['password'], $user->password)) {
+            throw ValidationException::withMessages([
+                'login' => [trans('auth.failed')],
+            ]);
+        }
+
+        $plainTextToken = bin2hex(random_bytes(32));
+        $hashedToken = hash('sha256', $plainTextToken);
+
+        $token = $user->apiTokens()->create([
+            'name' => $validated['device_name'] ?? $request->userAgent() ?? 'api-token',
+            'token' => $hashedToken,
+            'abilities' => $validated['abilities'] ?? ['*'],
+            'expires_at' => $this->determineExpiration(),
+        ]);
+
+        return response()->json([
+            'token' => $plainTextToken,
+            'token_type' => 'Bearer',
+            'expires_at' => $token->expires_at?->toISOString(),
+        ], 201);
+    }
+
+    /**
+     * Show the authenticated user.
+     */
+    public function show(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        return response()->json([
+            'id' => $user->id,
+            'login' => $user->login,
+            'name' => $user->name,
+            'email' => $user->email,
+            'role' => $user->default_role,
+            'language' => $user->language,
+        ]);
+    }
+
+    /**
+     * Revoke the current API token.
+     */
+    public function destroy(Request $request): JsonResponse
+    {
+        $token = ApiToken::findActiveToken($request->bearerToken());
+
+        if ($token) {
+            $token->delete();
+        }
+
+        return response()->json([
+            'message' => 'Token revoked',
+        ]);
+    }
+
+    private function determineExpiration(): ?CarbonInterface
+    {
+        $minutes = (int) config('api.token_expiration_minutes', 43200);
+
+        if ($minutes <= 0) {
+            return null;
+        }
+
+        return now()->addMinutes($minutes);
+    }
+}

--- a/app/Models/ApiToken.php
+++ b/app/Models/ApiToken.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ApiToken extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'api_tokens';
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $guarded = ['id', 'created_at', 'updated_at'];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'abilities' => 'array',
+        'last_used_at' => 'datetime',
+        'expires_at' => 'datetime',
+    ];
+
+    /**
+     * Related user for the token.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Scope for active (non-expired) tokens.
+     */
+    public function scopeActive($query)
+    {
+        return $query->where(function ($query) {
+            $query->whereNull('expires_at')->orWhere('expires_at', '>', now());
+        });
+    }
+
+    /**
+     * Find an active token from a plain text value.
+     */
+    public static function findActiveToken(?string $plainTextToken): ?self
+    {
+        if (empty($plainTextToken)) {
+            return null;
+        }
+
+        $hashedToken = hash('sha256', $plainTextToken);
+
+        return self::query()
+            ->where('token', $hashedToken)
+            ->active()
+            ->first();
+    }
+
+    /**
+     * Check if the token has a given ability.
+     */
+    public function hasAbility(string $ability): bool
+    {
+        $abilities = $this->abilities ?? ['*'];
+
+        return in_array('*', $abilities, true) || in_array($ability, $abilities, true);
+    }
+
+    /**
+     * Determine if the token is expired.
+     */
+    public function isExpired(): bool
+    {
+        return $this->expires_at instanceof CarbonInterface
+            && $this->expires_at->isPast();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,8 +2,10 @@
 
 namespace App\Models;
 
+use App\Models\ApiToken;
 use App\Traits\TrimsCharColumns;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -162,5 +164,15 @@ class User extends Authenticatable
     public function renewals()
     {
         return $this->matters()->has('renewalsPending')->with('renewalsPending');
+    }
+
+    /**
+     * API tokens issued for this user.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function apiTokens(): HasMany
+    {
+        return $this->hasMany(ApiToken::class);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Models\Actor;
 use App\Models\ActorPivot;
+use App\Models\ApiToken;
 use App\Models\Category;
 use App\Models\Classifier;
 use App\Models\ClassifierType;
@@ -39,6 +40,8 @@ use App\Policies\TemplateClassPolicy;
 use App\Policies\TemplateMemberPolicy;
 use App\Policies\UserPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -66,5 +69,17 @@ class AuthServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->registerPolicies();
+
+        Auth::viaRequest('api-token', function (Request $request) {
+            $token = ApiToken::findActiveToken($request->bearerToken());
+
+            if ($token) {
+                $token->forceFill(['last_used_at' => now()])->saveQuietly();
+
+                return $token->user;
+            }
+
+            return null;
+        });
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/config/api.php
+++ b/config/api.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | API Rate Limits
+    |--------------------------------------------------------------------------
+    |
+    | Configure per-minute rate limits for API calls and authentication attempts.
+    | Set the environment variables to tune these limits in different
+    | environments without changing code.
+    |
+    */
+    'rate_limit' => env('API_RATE_LIMIT', 120),
+    'auth_rate_limit' => env('API_AUTH_RATE_LIMIT', 10),
+
+    /*
+    |--------------------------------------------------------------------------
+    | API Token Expiration
+    |--------------------------------------------------------------------------
+    |
+    | Tokens expire after the configured number of minutes. Set to null or zero
+    | to create non-expiring tokens (not recommended for production).
+    |
+    */
+    'token_expiration_minutes' => env('API_TOKEN_EXPIRATION', 43200), // 30 days
+];

--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'api' => [
+            'driver' => 'api-token',
+            'provider' => 'users',
+        ],
     ],
 
     /*

--- a/database/migrations/2025_12_25_000001_create_api_tokens_table.php
+++ b/database/migrations/2025_12_25_000001_create_api_tokens_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('api_tokens', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('user_id')->constrained('actor')->cascadeOnDelete();
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->jsonb('abilities')->nullable();
+            $table->timestampTz('last_used_at')->nullable();
+            $table->timestampTz('expires_at')->nullable();
+            $table->timestampsTz();
+
+            $table->index('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('api_tokens');
+    }
+};

--- a/docs/api-authentication.md
+++ b/docs/api-authentication.md
@@ -1,0 +1,52 @@
+# API Authentication
+
+Token-based API authentication is now available for integrations. Use the endpoints under `/api/auth` to issue and revoke tokens, then include the bearer token in the `Authorization` header when calling protected API routes.
+
+## Endpoints
+
+| Endpoint | Method | Description | Middleware |
+| --- | --- | --- | --- |
+| `/api/auth/token` | POST | Exchange phpIP credentials for a bearer token. | `throttle:api-auth` |
+| `/api/auth/me` | GET | Return the authenticated user's profile. | `auth:api`, `throttle:api` |
+| `/api/auth/logout` | POST | Revoke the currently used token. | `auth:api`, `throttle:api` |
+| `/api/ping` | GET | Simple authenticated health probe. | `auth:api`, `throttle:api` |
+
+## Request examples
+
+### Issue a token
+
+```bash
+curl -X POST https://your-domain.example.com/api/auth/token \
+  -H "Content-Type: application/json" \
+  -d '{
+    "login": "phpipuser",
+    "password": "changeme",
+    "device_name": "integration-script"
+  }'
+```
+
+### Call a protected endpoint
+
+```bash
+curl https://your-domain.example.com/api/auth/me \
+  -H "Authorization: Bearer <token-from-response>"
+```
+
+### Revoke the current token
+
+```bash
+curl -X POST https://your-domain.example.com/api/auth/logout \
+  -H "Authorization: Bearer <token-from-response>"
+```
+
+## Configuration
+
+Adjust these environment variables to tune rate limits and token lifetime:
+
+- `API_RATE_LIMIT` – maximum API calls per minute (default: 120)
+- `API_AUTH_RATE_LIMIT` – maximum token issuance attempts per minute (default: 10)
+- `API_TOKEN_EXPIRATION` – token expiration in minutes; set to `0` or leave empty for non-expiring tokens
+
+## OpenAPI
+
+An OpenAPI specification for the authentication endpoints lives at `docs/openapi/api-authentication.yaml`.

--- a/docs/openapi/api-authentication.yaml
+++ b/docs/openapi/api-authentication.yaml
@@ -1,0 +1,108 @@
+openapi: 3.1.0
+info:
+  title: phpIP API Authentication
+  version: "1.0.0"
+  description: |
+    Token-based authentication endpoints for phpIP integrations.
+servers:
+  - url: https://your-domain.example.com
+    description: Production
+  - url: http://localhost:8000
+    description: Local development
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: Token
+paths:
+  /api/auth/token:
+    post:
+      summary: Issue an API token
+      description: Exchange phpIP credentials for a bearer token with optional abilities and expiry.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - login
+                - password
+              properties:
+                login:
+                  type: string
+                  example: phpipuser
+                password:
+                  type: string
+                  format: password
+                device_name:
+                  type: string
+                  example: integration-script
+                abilities:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: Token created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    description: Bearer token to send in the Authorization header
+                  token_type:
+                    type: string
+                    example: Bearer
+                  expires_at:
+                    type: string
+                    format: date-time
+        '422':
+          description: Invalid credentials
+        '429':
+          description: Too many attempts on the auth endpoint
+  /api/auth/me:
+    get:
+      security:
+        - BearerAuth: []
+      summary: Get the authenticated user
+      responses:
+        '200':
+          description: Authenticated user profile
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  login:
+                    type: string
+                  name:
+                    type: string
+                  email:
+                    type: string
+                    format: email
+                  role:
+                    type: string
+                  language:
+                    type: string
+        '401':
+          description: Missing or invalid token
+        '429':
+          description: Rate limit exceeded
+  /api/auth/logout:
+    post:
+      security:
+        - BearerAuth: []
+      summary: Revoke the current token
+      responses:
+        '200':
+          description: Token revoked successfully
+        '401':
+          description: Missing or invalid token
+        '429':
+          description: Rate limit exceeded

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Http\Controllers\Api\ApiTokenController;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('auth')->group(function () {
+    Route::post('token', [ApiTokenController::class, 'store'])->middleware('throttle:api-auth');
+
+    Route::middleware(['auth:api', 'throttle:api'])->group(function () {
+        Route::get('me', [ApiTokenController::class, 'show']);
+        Route::post('logout', [ApiTokenController::class, 'destroy']);
+    });
+});
+
+Route::middleware(['auth:api', 'throttle:api'])->get('/ping', function (Request $request) {
+    return response()->json([
+        'status' => 'ok',
+        'login' => $request->user()->login,
+    ]);
+});

--- a/tests/Feature/Api/ApiAuthenticationTest.php
+++ b/tests/Feature/Api/ApiAuthenticationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class ApiAuthenticationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        RateLimiter::clear('api');
+        RateLimiter::clear('api-auth');
+    }
+
+    public function test_token_is_issued_with_valid_credentials(): void
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('secret-password'),
+        ]);
+
+        $response = $this->postJson('/api/auth/token', [
+            'login' => $user->login,
+            'password' => 'secret-password',
+            'device_name' => 'ci-suite',
+            'abilities' => ['read'],
+        ]);
+
+        $response->assertCreated()->assertJsonStructure([
+            'token',
+            'token_type',
+            'expires_at',
+        ]);
+
+        $this->assertDatabaseHas('api_tokens', [
+            'user_id' => $user->id,
+            'name' => 'ci-suite',
+        ]);
+    }
+
+    public function test_protected_route_requires_valid_token(): void
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('secret-password'),
+        ]);
+
+        $tokenResponse = $this->postJson('/api/auth/token', [
+            'login' => $user->login,
+            'password' => 'secret-password',
+        ])->assertCreated();
+
+        $token = $tokenResponse->json('token');
+
+        $this->getJson('/api/auth/me')->assertUnauthorized();
+
+        $this->getJson('/api/auth/me', [
+            'Authorization' => "Bearer {$token}",
+        ])->assertOk()->assertJsonFragment([
+            'login' => $user->login,
+            'email' => $user->email,
+        ]);
+    }
+
+    public function test_token_can_be_revoked(): void
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('secret-password'),
+        ]);
+
+        $token = $this->postJson('/api/auth/token', [
+            'login' => $user->login,
+            'password' => 'secret-password',
+        ])->json('token');
+
+        $this->assertDatabaseCount('api_tokens', 1);
+
+        $this->postJson('/api/auth/logout', [], [
+            'Authorization' => "Bearer {$token}",
+        ])->assertOk();
+
+        $this->assertDatabaseCount('api_tokens', 0);
+
+        $this->getJson('/api/auth/me', [
+            'Authorization' => "Bearer {$token}",
+        ])->assertUnauthorized();
+    }
+
+    public function test_auth_endpoint_respects_rate_limit_configuration(): void
+    {
+        Config::set('api.auth_rate_limit', 1);
+        RateLimiter::clear('api-auth');
+
+        $user = User::factory()->create([
+            'password' => bcrypt('secret-password'),
+        ]);
+
+        $this->postJson('/api/auth/token', [
+            'login' => $user->login,
+            'password' => 'secret-password',
+        ])->assertCreated();
+
+        $this->postJson('/api/auth/token', [
+            'login' => $user->login,
+            'password' => 'secret-password',
+        ])->assertStatus(429);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated API token model, guard, and rate-limited endpoints for bearer authentication
- provide migration, configuration defaults, and environment samples for API token issuance
- document the new API authentication flow with OpenAPI and add feature coverage

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install was blocked by packagist 403; dependencies need installation to run the suite)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce07f9b1c832292fa442d57c709e4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token-based API authentication with configurable token expiration
  * API rate limiting controls for general and authentication endpoints
  * New authentication endpoints for token issuance, user profile access, and token revocation

* **Documentation**
  * Added API authentication guide with usage examples
  * Added OpenAPI specification for token-based authentication

* **Configuration**
  * New environment variables for rate limiting and token expiration settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->