### PR TITLE
refactor: Use PHPUnit data providers in BaselineMigrationTest

### DIFF
--- a/tests/Feature/Migrations/BaselineMigrationTest.php
+++ b/tests/Feature/Migrations/BaselineMigrationTest.php
@@ -56,6 +56,11 @@ class BaselineMigrationTest extends TestCase
     /**
      * Provides table names and their expected columns for structure verification.
      * Organized by dependency tiers.
+     *
+     * Note: Tables with empty column arrays or partial column lists are managed
+     * by third-party packages (Laravel framework or Auditable package) whose
+     * structure can change between versions. These tables are still verified
+     * to exist, but full column validation is not performed.
      */
     public static function tableStructureProvider(): array
     {
@@ -88,12 +93,12 @@ class BaselineMigrationTest extends TestCase
             'event_class_lnk' => ['event_class_lnk', ['id', 'event_name_code', 'template_class_id']],
             'renewals_logs' => ['renewals_logs', ['id', 'task_id']],
 
-            // Tier 5: Laravel Standard Tables
+            // Tier 5: Laravel Standard Tables (framework-managed, existence-only check)
             'migrations' => ['migrations', []],
             'password_resets' => ['password_resets', []],
             'failed_jobs' => ['failed_jobs', []],
 
-            // Tier 6: Audit Table
+            // Tier 6: Audit Table (managed by Auditable package, partial key columns)
             'audit_logs' => ['audit_logs', ['id', 'auditable_type', 'auditable_id']],
         ];
     }


### PR DESCRIPTION
Consolidate 42 repetitive test methods into 4 data-driven tests:
- tableStructureProvider: 24 table structure tests
- viewProvider: 5 view existence tests (with column checks for users)
- functionProvider: 6 stored function existence tests
- triggerProvider: 7 trigger existence tests

Summary tests (test_all_expected_*) kept unchanged for aggregate
verification.

Code reduction: 487 → 295 lines (~40% reduction, 329 lines removed)
Uses PHP 8.1 #[DataProvider] attribute syntax.

Resolves Issue 009.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Converted migration validation tests to a data-driven format with providers, consolidating repetitive checks into unified, parameterized tests for tables, views, functions and triggers.
  * Added providers and parameterized tests to improve maintainability and clearer failure reporting across migration validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->