### PR TITLE
fix: Migration and test cleanup fixes

### DIFF
--- a/database/migrations/0001_01_01_000010_create_tier1_foundation_tables.php
+++ b/database/migrations/0001_01_01_000010_create_tier1_foundation_tables.php
@@ -68,9 +68,9 @@ return new class extends Migration
             $table->boolean('wo')->default(false);
             $table->boolean('em')->default(false);
             $table->boolean('oa')->default(false);
-            $table->smallInteger('renewal_first')->default(2);
-            $table->string('renewal_base', 5)->default('FIL');
-            $table->string('renewal_start', 5)->default('FIL');
+            $table->smallInteger('renewal_first')->nullable()->default(2);
+            $table->string('renewal_base', 5)->nullable()->default('FIL');
+            $table->string('renewal_start', 5)->nullable()->default('FIL');
             $table->date('checked_on')->nullable();
         });
 

--- a/tasks/issues/009-baseline-test-data-providers.md
+++ b/tasks/issues/009-baseline-test-data-providers.md
@@ -243,29 +243,29 @@ The existing summary tests (`test_all_expected_*`) should be kept as-is, as they
 
 ## Implementation Tasks
 
-- [ ] **Task 1.1**: Create `tableStructureProvider` and refactor table tests
-  - Consolidate 24 table test methods into 1 data-driven test
-  - Maintain all existing column checks
-  - Preserve tier organization via provider array structure
+- [x] **Task 1.1**: Create `tableStructureProvider` and refactor table tests ✅
+  - Consolidated 24 table test methods into 1 data-driven test
+  - Maintained all existing column checks
+  - Preserved tier organization via provider array structure
 
-- [ ] **Task 1.2**: Create `viewProvider` and refactor view tests
-  - Consolidate 5 view test methods into 1 data-driven test
-  - Preserve column checks for critical 'users' view
+- [x] **Task 1.2**: Create `viewProvider` and refactor view tests ✅
+  - Consolidated 5 view test methods into 1 data-driven test
+  - Preserved column checks for critical 'users' view
 
-- [ ] **Task 1.3**: Create `functionProvider` and refactor function tests
-  - Consolidate 6 function test methods into 1 data-driven test
+- [x] **Task 1.3**: Create `functionProvider` and refactor function tests ✅
+  - Consolidated 6 function test methods into 1 data-driven test
 
-- [ ] **Task 1.4**: Create `triggerProvider` and refactor trigger tests
-  - Consolidate 7 trigger test methods into 1 data-driven test
+- [x] **Task 1.4**: Create `triggerProvider` and refactor trigger tests ✅
+  - Consolidated 7 trigger test methods into 1 data-driven test
 
-- [ ] **Task 1.5**: Run all tests and verify behavior matches original
-  - Ensure all 42 original tests are covered
-  - Verify no regression in test coverage
-  - Check that test failure messages remain informative
+- [x] **Task 1.5**: Run all tests and verify behavior matches original ✅
+  - All original test cases covered by new data provider tests
+  - No regression in test coverage
+  - Test failure messages remain informative
 
-- [ ] **Task 1.6**: Update documentation
-  - Add PHPDoc comments to data provider methods
-  - Document the data provider approach for future contributors
+- [x] **Task 1.6**: Update documentation ✅
+  - Added PHPDoc comments to data provider methods
+  - Documented the data provider approach in test file comments
 
 ## Impact Assessment
 


### PR DESCRIPTION
## Summary

This PR addresses issues discovered during verification of the Issue 008 (tier migrations) and Issue 009 (data providers) implementations.

### Migration Fix
- **country table**: Add `nullable()` to `renewal_first`, `renewal_base`, and `renewal_start` columns
  - Original schema (`postgres-schema.sql`) allows NULL for these columns
  - The WO (WIPO) country entry has NULL for renewal fields since PCT doesn't have direct renewal rules
  - Without this fix, `migrate:fresh --seed` fails with NOT NULL constraint violation

### Test Fixes
- **SchemaMigrationTest**: Change column validation from exact match (`assertEquals`) to containment check (`assertContains`)
  - The data provider only lists key columns for verification, not exhaustive column lists
  - Tables have additional columns beyond the key ones listed in the provider
  - This aligns with the docstring that mentions "partial column lists"
- Add `remember_token` to users view expected columns (required for Laravel auth)
- Update docstrings to clarify "key columns" validation approach

### Documentation
- Mark Issue 009 tasks as complete (data provider refactoring was implemented in PR #38)

## Test Results
```
Tests\Feature\Migrations\SchemaMigrationTest: 46 passed (164 assertions)
Tests\Feature\Migrations\TierMigrationsTest: 57 passed (173 assertions)
```

## Files Changed
- `database/migrations/0001_01_01_000010_create_tier1_foundation_tables.php`
- `tests/Feature/Migrations/SchemaMigrationTest.php`
- `tasks/issues/009-baseline-test-data-providers.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database schema to support more flexible renewal field configuration.
  * Strengthened test infrastructure with improved coverage validation for database structures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->