### PR TITLE
fix: Handle PostgreSQL CHAR column padding in login authentication

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -3,7 +3,10 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * Handles user authentication and login.
@@ -54,5 +57,30 @@ class LoginController extends Controller
     public function username()
     {
         return 'login';
+    }
+
+    /**
+     * Attempt to log the user into the application.
+     *
+     * Overrides default behavior to handle PostgreSQL CHAR column padding.
+     * The login column is CHAR(16) which gets padded with spaces, so we use
+     * TRIM() in the query to compare correctly.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function attemptLogin(Request $request)
+    {
+        $login = $request->input($this->username());
+        $password = $request->input('password');
+
+        // Find user using TRIM() to handle CHAR column padding
+        $user = User::whereRaw('TRIM(login) = ?', [$login])->first();
+
+        if ($user && Auth::attempt(['login' => $user->login, 'password' => $password], $request->boolean('remember'))) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- Fix login authentication failure caused by PostgreSQL CHAR column padding
- The `login` column is `CHAR(16)` which pads values with trailing spaces
- `Auth::attempt()` queries `WHERE login = 'phpipuser'` but stored value is `'phpipuser       '`
- Override `attemptLogin()` to use `TRIM()` in the query for correct matching

## Problem
Users could not log in because PostgreSQL CHAR columns are fixed-length and pad values with spaces to fill the defined width. Laravel's authentication compares the user input directly against the padded database value, which fails.

## Solution
Override the `attemptLogin()` method in `LoginController` to:
1. Find the user using `TRIM(login)` in a raw query
2. Then use `Auth::attempt()` with the actual (padded) login value from the database

```php
protected function attemptLogin(Request $request)
{
    $login = $request->input($this->username());
    $password = $request->input('password');

    // Find user using TRIM() to handle CHAR column padding
    $user = User::whereRaw('TRIM(login) = ?', [$login])->first();

    if ($user && Auth::attempt(['login' => $user->login, 'password' => $password], $request->boolean('remember'))) {
        return true;
    }

    return false;
}
```

## Test plan
- [x] All 1332 existing tests pass
- [x] Manual E2E testing confirms login works with `phpipuser` / `password`
- [x] Verified in browser that authentication succeeds and redirects to dashboard

## Related
Found during E2E GUI testing session on 2025-12-29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login handling to account for fixed-width database field padding (e.g., PostgreSQL CHAR), reducing unexpected failed sign-ins and providing a more reliable, seamless authentication experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->